### PR TITLE
Fix missed CDN invalidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.0.2 - 2024-03-22
+
+- Fixed a bug where CDN invalidations would not be triggered when an asset was renamed or replaced. ([#14](https://github.com/craftcms/flysystem/pull/14))
+
 ## 1.0.1 - 2024-01-17
 
 - Fixed a bug where `craft\flysystem\base\FlysystemFs::directoryExists()` was calling `fileExists()` on the Flysystem adapter, rather than `directoryExists()`. ([#11](https://github.com/craftcms/flysystem/issues/11))

--- a/src/base/FlysystemFs.php
+++ b/src/base/FlysystemFs.php
@@ -177,6 +177,8 @@ abstract class FlysystemFs extends Fs
         } catch (FilesystemException | UnableToMoveFile $exception) {
             throw new FsException($exception->getMessage(), 0, $exception);
         }
+
+        $this->invalidateCdnPath($path);
     }
 
     /**
@@ -240,6 +242,8 @@ abstract class FlysystemFs extends Fs
         } catch (FilesystemException | UnableToDeleteDirectory $exception) {
             throw new FsException($exception->getMessage(), 0, $exception);
         }
+
+        $this->invalidateCdnPath($path);
     }
 
     /**


### PR DESCRIPTION
### Description
Rename/replacing assets were not trigging CDN invalidations.

I've also added it to `deleteDirectory`, as we really can't assume that the implementing adapter can't delete dirs (like s3).

Need to merge `1.x` into `2.x` after merging.